### PR TITLE
update to work with sublime text 3 and fix subl:// handler format

### DIFF
--- a/Sublime Text 2 Launcher.app/Contents/Resources/Scripts/subl-launcher.py
+++ b/Sublime Text 2 Launcher.app/Contents/Resources/Scripts/subl-launcher.py
@@ -6,7 +6,18 @@ from urlparse import parse_qs
 from urllib import unquote
 import subprocess
 
-x = parse_qs(urlparse(unquote(sys.argv[1])).path)
-path = urlparse(x['?url'][0]).path
+# this will handle the following type of link:
+# subl://open?url=file://%2FUsers%2Fexample%2Frails%2Fapp1%2Fapp%2Fmodels%2Ftest.rb&line=123
+#
+# tested and debugged from the command line by running something like:
+# ./subl-launcher.py 'subl://open?url=file://%2FUsers%2Fexample%2Frails%2Fapp1%2Fapp%2Fmodels%2Ftest.rb&line=123'
+#
+# it could use a little work with better error handling for when
+# it gets a string that doesn't fit the desired format, but if
+# the format is right it seems to work well
+
+x = parse_qs(urlparse(unquote(sys.argv[1])).query)
+path = x['url'][0].replace('file://','')
 line = x['line'][0]
-subprocess.call(['/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl', '%s:%s' % (path, line)])
+subprocess.call(['/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl', '%s:%s' % (path, line)])
+


### PR DESCRIPTION
this will handle the following type of link:

```
subl://open?url=file://%2FUsers%2Fexample%2Frails%2Fapp1%2Fapp%2Fmodels%2Ftest.rb&line=123
```

tested and debugged from the command line by running something like:

```
./subl-launcher.py 'subl://open?url=file://%2FUsers%2Fexample%2Frails%2Fapp1%2Fapp%2Fmodels%2Ftest.rb&line=123'
```

it could use a little work with better error handling for when it gets a string that doesn't fit the desired format, but if the format is right it seems to work well.

Works with shock's installation instructions from https://github.com/charliesome/better_errors/issues/100#issuecomment-47147285 

ps: For the better_errors gem I am using the override `BetterErrors.editor = :subl` in my `config/application.rb`
